### PR TITLE
Refine DataTaskClient implementation

### DIFF
--- a/Sources/Wired/Client/DataTaskClient+Combine.swift
+++ b/Sources/Wired/Client/DataTaskClient+Combine.swift
@@ -7,8 +7,8 @@ extension DataTaskClient {
     public func dataPublisher<T>(request: T) -> AnyPublisher<Data, LocalError>
     where T: RequestBuildable
     {
-        return Future { [unowned self] promise in
-            retrieveData(request: request, completion: promise)
+        return Future { [weak self] promise in
+            self?.retrieveData(request: request, completion: promise)
         }
         .eraseToAnyPublisher()
     }
@@ -17,8 +17,8 @@ extension DataTaskClient {
     where T: RequestBuildable,
           U: ResponseConvertible
     {
-        return Future { [unowned self] promise in
-            retrieveObject(request: request, dataConverter: dataConverter, completion: promise)
+        return Future { [weak self] promise in
+            self?.retrieveObject(request: request, dataConverter: dataConverter, completion: promise)
         }
         .eraseToAnyPublisher()
     }
@@ -26,8 +26,8 @@ extension DataTaskClient {
     public func objectPublisher<T>(request: T) -> AnyPublisher<T.Output, LocalError>
     where T: RequestBuildable & ResponseConvertible
     {
-        return Future { [unowned self] promise in
-            retrieveObject(request: request, completion: promise)
+        return Future { [weak self] promise in
+            self?.retrieveObject(request: request, completion: promise)
         }
         .eraseToAnyPublisher()
     }

--- a/Sources/Wired/Client/DataTaskClient+Combine.swift
+++ b/Sources/Wired/Client/DataTaskClient+Combine.swift
@@ -13,21 +13,21 @@ extension DataTaskClient {
         .eraseToAnyPublisher()
     }
 
-    public func responsePublisher<T, U>(request: T, dataConverter: U) -> AnyPublisher<U.Output, LocalError>
+    public func objectPublisher<T, U>(request: T, dataConverter: U) -> AnyPublisher<U.Output, LocalError>
     where T: RequestBuildable,
           U: ResponseConvertible
     {
         return Future { [unowned self] promise in
-            retrieveResponse(request: request, dataConverter: dataConverter, completion: promise)
+            retrieveObject(request: request, dataConverter: dataConverter, completion: promise)
         }
         .eraseToAnyPublisher()
     }
 
-    public func responsePublisher<T>(request: T) -> AnyPublisher<T.Output, LocalError>
+    public func objectPublisher<T>(request: T) -> AnyPublisher<T.Output, LocalError>
     where T: RequestBuildable & ResponseConvertible
     {
         return Future { [unowned self] promise in
-            retrieveResponse(request: request, completion: promise)
+            retrieveObject(request: request, completion: promise)
         }
         .eraseToAnyPublisher()
     }

--- a/Sources/Wired/Client/DataTaskClient+Combine.swift
+++ b/Sources/Wired/Client/DataTaskClient+Combine.swift
@@ -27,7 +27,7 @@ extension DataTaskClient {
     where T: RequestBuildable & ResponseConvertible
     {
         return Future { [weak self] promise in
-            self?.retrieveObject(request: request, completion: promise)
+            self?.retrieveObject(convertibleRequest: request, completion: promise)
         }
         .eraseToAnyPublisher()
     }

--- a/Sources/Wired/Client/DataTaskClient.swift
+++ b/Sources/Wired/Client/DataTaskClient.swift
@@ -21,10 +21,10 @@ public final class DataTaskClient {
     ///   - request: An object that addresses both the generation of `URLRequest` and conversion from `Data` into an `Output` value.
     ///   - completion: A completion handler.
     @discardableResult
-    public func retrieveResponse<T>(request: T, completion: @escaping Completion<T.Output>) -> URLSessionDataTask?
+    public func retrieveObject<T>(request: T, completion: @escaping Completion<T.Output>) -> URLSessionDataTask?
     where T: RequestBuildable & ResponseConvertible
     {
-        return retrieveResponse(request: request, dataConverter: request, completion: completion)
+        return retrieveObject(request: request, dataConverter: request, completion: completion)
     }
 
     /// Retrieves the contents of a request, transforms the obtained data into a specific object, and calls a handler upon completion.
@@ -33,7 +33,7 @@ public final class DataTaskClient {
     ///   - dataConverter: An object that transforms `Data` into an `Output` value.
     ///   - completion: A completion handler.
     @discardableResult
-    public func retrieveResponse<T, U>(request: T, dataConverter: U, completion: @escaping Completion<U.Output>) -> URLSessionDataTask?
+    public func retrieveObject<T, U>(request: T, dataConverter: U, completion: @escaping Completion<U.Output>) -> URLSessionDataTask?
     where T: RequestBuildable,
           U: ResponseConvertible
     {

--- a/Sources/Wired/Client/DataTaskClient.swift
+++ b/Sources/Wired/Client/DataTaskClient.swift
@@ -3,15 +3,17 @@ import Foundation
 public final class DataTaskClient {
     public typealias Completion<T> = (Result<T, LocalError>) -> Void
 
-    /// The shared object of `DataTaskClient`.
-    public static let shared: DataTaskClient = DataTaskClient(configuration: .default)
+    /// The shared object of `DataTaskClient` that uses `URLSession.shared` as its session.
+    public static let shared: DataTaskClient = DataTaskClient()
 
-    private let configuration: URLSessionConfiguration
+    private let session: URLSession
 
-    private lazy var session: URLSession = URLSession(configuration: configuration)
+    public init(session: URLSession = .shared) {
+        self.session = session
+    }
 
-    public init(configuration: URLSessionConfiguration) {
-        self.configuration = configuration
+    public init(configuration: URLSessionConfiguration, delegateQueue: OperationQueue? = nil) {
+        self.session = URLSession(configuration: configuration, delegate: nil, delegateQueue: delegateQueue)
     }
 
     /// Retrieves the contents of a request, transforms the obtained data into a specific object, and calls a handler upon completion.

--- a/Sources/Wired/Request/Request.swift
+++ b/Sources/Wired/Request/Request.swift
@@ -78,13 +78,13 @@ extension Request {
         let dataConverter = ResponseConverter { data -> Result<Data, Error> in
             return modifyResponse(data: data)
         }
-        DataTaskClient.shared.retrieveResponse(request: self, dataConverter: dataConverter, completion: completion)
+        DataTaskClient.shared.retrieveObject(request: self, dataConverter: dataConverter, completion: completion)
     }
 
     public func getObject<T>(ofType: T.Type, using decoder: JSONDecoder = JSONDecoder(), completion: @escaping (Result<T, LocalError>) -> Void)
     where T: Decodable
     {
-        DataTaskClient.shared.retrieveResponse(request: self,
+        DataTaskClient.shared.retrieveObject(request: self,
                                                dataConverter: JSONConverter<T>(decoder: decoder),
                                                completion: completion)
     }
@@ -105,7 +105,7 @@ extension Request {
     public func objectPublisher<T>(ofType: T.Type, using decoder: JSONDecoder = JSONDecoder()) -> AnyPublisher<T, LocalError>
     where T: Decodable
     {
-        return DataTaskClient.shared.responsePublisher(request: self, dataConverter: JSONConverter<T>(decoder: decoder))
+        return DataTaskClient.shared.objectPublisher(request: self, dataConverter: JSONConverter<T>(decoder: decoder))
     }
 }
 #endif

--- a/Sources/Wired/Request/Request.swift
+++ b/Sources/Wired/Request/Request.swift
@@ -84,9 +84,7 @@ extension Request {
     public func getObject<T>(ofType: T.Type, using decoder: JSONDecoder = JSONDecoder(), completion: @escaping (Result<T, LocalError>) -> Void)
     where T: Decodable
     {
-        DataTaskClient.shared.retrieveObject(request: self,
-                                               dataConverter: JSONConverter<T>(decoder: decoder),
-                                               completion: completion)
+        DataTaskClient.shared.retrieveObject(request: self, dataConverter: JSONConverter<T>(decoder: decoder), completion: completion)
     }
 }
 

--- a/Sources/Wired/Request/Resource.swift
+++ b/Sources/Wired/Request/Resource.swift
@@ -37,7 +37,7 @@ extension Resource {
     public func getObject<T>(ofType: T.Type, using decoder: JSONDecoder = JSONDecoder(), completion: @escaping (Result<T, LocalError>) -> Void)
     where T: Decodable
     {
-        DataTaskClient.shared.retrieveResponse(request: self,
+        DataTaskClient.shared.retrieveObject(request: self,
                                                dataConverter: JSONConverter<T>(decoder: decoder),
                                                completion: completion)
     }
@@ -55,7 +55,7 @@ extension Resource {
     public func objectPublisher<T>(ofType: T.Type, using decoder: JSONDecoder = JSONDecoder()) -> AnyPublisher<T, LocalError>
     where T: Decodable
     {
-        return DataTaskClient.shared.responsePublisher(request: self, dataConverter: JSONConverter<T>(decoder: decoder))
+        return DataTaskClient.shared.objectPublisher(request: self, dataConverter: JSONConverter<T>(decoder: decoder))
     }
 }
 #endif

--- a/Sources/Wired/Request/Resource.swift
+++ b/Sources/Wired/Request/Resource.swift
@@ -37,9 +37,7 @@ extension Resource {
     public func getObject<T>(ofType: T.Type, using decoder: JSONDecoder = JSONDecoder(), completion: @escaping (Result<T, LocalError>) -> Void)
     where T: Decodable
     {
-        DataTaskClient.shared.retrieveObject(request: self,
-                                               dataConverter: JSONConverter<T>(decoder: decoder),
-                                               completion: completion)
+        DataTaskClient.shared.retrieveObject(request: self, dataConverter: JSONConverter<T>(decoder: decoder), completion: completion)
     }
 }
 


### PR DESCRIPTION
- Provide flexible init methods
- Rename `retrieveResponse` to `retrieveObject`
- Use `weak` instead of `unowned` for safety
- Dispatch data converting operation to a separate queue