### PR TITLE
Change `HTTPMethod` to a struct

### DIFF
--- a/Sources/Wire/Model/HTTPMethod.swift
+++ b/Sources/Wire/Model/HTTPMethod.swift
@@ -1,14 +1,20 @@
 import Foundation
 
 /// Represents a HTTP method.
-public enum HTTPMethod: String {
-    case get = "GET"
-    case head = "HEAD"
-    case post = "POST"
-    case put = "PUT"
-    case delete = "DELETE"
-    case connect = "CONNECT"
-    case options = "OPTIONS"
-    case trace = "TRACE"
-    case patch = "PATCH"
+public struct HTTPMethod {
+    public static let get: HTTPMethod = HTTPMethod(value: "GET")
+    public static let head: HTTPMethod = HTTPMethod(value: "HEAD")
+    public static let post: HTTPMethod = HTTPMethod(value: "POST")
+    public static let put: HTTPMethod = HTTPMethod(value: "PUT")
+    public static let delete: HTTPMethod = HTTPMethod(value: "DELETE")
+    public static let connect: HTTPMethod = HTTPMethod(value: "CONNECT")
+    public static let options: HTTPMethod = HTTPMethod(value: "OPTIONS")
+    public static let trace: HTTPMethod = HTTPMethod(value: "TRACE")
+    public static let patch: HTTPMethod = HTTPMethod(value: "PATCH")
+
+    public let value: String
+
+    public init(value: String) {
+        self.value = value
+    }
 }

--- a/Sources/Wire/Request/Resource.swift
+++ b/Sources/Wire/Request/Resource.swift
@@ -35,7 +35,7 @@ public struct Resource: RequestBuildable {
 
     public func buildRequest() -> Result<URLRequest, Error> {
         var urlRequest = URLRequest(url: url)
-        urlRequest.httpMethod = method.rawValue
+        urlRequest.httpMethod = method.value
         headers.forEach { $0.modify(request: &urlRequest) }
         urlRequest.httpBody = body
         return .success(urlRequest)

--- a/Tests/WireTests/RequestModifierTests.swift
+++ b/Tests/WireTests/RequestModifierTests.swift
@@ -5,7 +5,7 @@ final class RequestModifierTests: XCTestCase {
     func testInit() {
         let requestModifier = RequestModifier { req -> Result<URLRequest, Error> in
             var req = req
-            req.httpMethod = HTTPMethod.post.rawValue
+            req.httpMethod = HTTPMethod.post.value
             return .success(req)
         }
         let origRequest = URLRequest(url: .demo)


### PR DESCRIPTION
- Increase flexibility by changing `HTTPMethod` to a struct