### PR TITLE
Modify HTTPHeader static functions API

### DIFF
--- a/Sources/Wire/Extensions/Optional+Ext.swift
+++ b/Sources/Wire/Extensions/Optional+Ext.swift
@@ -1,7 +1,0 @@
-import Foundation
-
-extension Optional {
-    func mapNil(as fallback: Wrapped) -> Wrapped {
-        return self ?? fallback
-    }
-}

--- a/Sources/Wire/Extensions/Optional+WithDefaultValue.swift
+++ b/Sources/Wire/Extensions/Optional+WithDefaultValue.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+protocol WithDefaultValue {
+    static var defaultValue: Self { get }
+}
+
+extension Optional where Wrapped: WithDefaultValue {
+    func unboxed(fallback defaultValue: Wrapped = Wrapped.defaultValue) -> Wrapped {
+        return self ?? defaultValue
+    }
+}
+
+extension Data: WithDefaultValue {
+    static var defaultValue: Data { Data() }
+}

--- a/Sources/Wire/Protocols/DataModifiable.swift
+++ b/Sources/Wire/Protocols/DataModifiable.swift
@@ -2,10 +2,10 @@ import Foundation
 
 /**
  Defines the `modify(_:)` method that consumes a data and
- outputs a failable result enclosing the modified data.
+ outputs a fallible result enclosing the modified data.
  */
 public protocol DataModifiable {
-    /// Modifies a chunk of data and returns a failable result wrapping the modified data.
+    /// Modifies a chunk of data and returns a fallible result wrapping the modified data.
     /// - Parameter input: A chunk of data being modified.
     func modify(_ input: Data) -> Result<Data, Error>
 }

--- a/Sources/Wire/Protocols/RequestBuildable.swift
+++ b/Sources/Wire/Protocols/RequestBuildable.swift
@@ -1,10 +1,10 @@
 import Foundation
 
 /**
- Defines the `buildRequest()` method which outputs a failable result enclosing a `URLRequest` instance.
+ Defines the `buildRequest()` method which outputs a fallible result enclosing a `URLRequest` instance.
  */
 public protocol RequestBuildable {
-    /// Returns a failable result wrapping a `URLRequest`.
+    /// Returns a fallible result wrapping a `URLRequest`.
     func buildRequest() -> Result<URLRequest, Error>
 }
 
@@ -23,7 +23,7 @@ extension URL: RequestBuildable {
 extension String: RequestBuildable {
     public func buildRequest() -> Result<URLRequest, Error> {
         guard let url = URL(string: self) else {
-            return .failure(WireBaseError.invalidURLString(self))
+            return .failure(WireError.invalidURLString(self))
         }
         return .success(URLRequest(url: url))
     }

--- a/Sources/Wire/Protocols/RequestModifiable.swift
+++ b/Sources/Wire/Protocols/RequestModifiable.swift
@@ -2,10 +2,10 @@ import Foundation
 
 /**
  Defines the `modify(_:)` method that consumes a URLRequest and
- outputs a failable result wrapping the modified request.
+ outputs a fallible result wrapping the modified request.
  */
 public protocol RequestModifiable {
-    /// Modifies a `URLRequest` and returns a failable result wrapping the modified request.
+    /// Modifies a `URLRequest` and returns a fallible result wrapping the modified request.
     /// - Parameter request: The request being modified.
     func modify(_ request: URLRequest) -> Result<URLRequest, Error>
 }

--- a/Sources/Wire/Protocols/ResponseConvertible.swift
+++ b/Sources/Wire/Protocols/ResponseConvertible.swift
@@ -2,13 +2,13 @@ import Foundation
 
 /**
  Defines the `convert(data:)` method that consumes a chunk of data and
- outputs a failable result wrapping the transformed value of type `Output`.
+ outputs a fallible result wrapping the transformed value of type `Output`.
  */
 public protocol ResponseConvertible {
-    /// The type which the input data is transformed to.
+    /// The type to which the input data is transformed.
     associatedtype Output
 
-    /// Transforms a chunk of data into a value typed `Output` and returns as a failable result.
+    /// Transforms a chunk of data into a value typed `Output` and returns as a fallible result.
     /// - Parameter data: The data to be converted.
     func convert(data: Data) -> Result<Output, Error>
 }

--- a/Sources/Wire/Public/DataTaskClient/DataTaskClient+Combine.swift
+++ b/Sources/Wire/Public/DataTaskClient/DataTaskClient+Combine.swift
@@ -4,7 +4,7 @@ import Foundation
 
 @available(iOS 13.0, tvOS 13.0, watchOS 6.0, OSX 10.15, *)
 extension DataTaskClient {
-    public func objectPublisher<T, U>(with builder: T, responseConverter: U) -> AnyPublisher<U.Output, WireBaseError>
+    public func objectPublisher<T, U>(with builder: T, responseConverter: U) -> AnyPublisher<U.Output, WireError>
     where T: RequestBuildable, U: ResponseConvertible {
         Future { [unowned self] promise in
             retrieveObject(with: builder, responseConverter: responseConverter, completion: promise)
@@ -12,7 +12,7 @@ extension DataTaskClient {
         .eraseToAnyPublisher()
     }
 
-    public func dataPublisher<T>(with builder: T) -> AnyPublisher<Data, WireBaseError>
+    public func dataPublisher<T>(with builder: T) -> AnyPublisher<Data, WireError>
     where T: RequestBuildable {
         Future { [unowned self] promise in
             retrieveData(with: builder, completion: promise)

--- a/Sources/Wire/Public/DataTaskClient/DataTaskClient+Error.swift
+++ b/Sources/Wire/Public/DataTaskClient/DataTaskClient+Error.swift
@@ -1,9 +1,9 @@
 import Foundation
 
 extension DataTaskClient {
-    public enum PerformError: LocalizedError {
+    public indirect enum Error: LocalizedError {
         /// `URLError` from `URLSession`. The `error` is ignored upon evaluating equality.
-        case sessionError(_ error: Error)
+        case sessionError(_ error: Swift.Error)
         /// No response from server
         case noResponse
         /// The response is not HTTP. The `response` is ignored upon evaluating equality.
@@ -33,7 +33,7 @@ extension DataTaskClient {
     }
 }
 
-extension DataTaskClient.PerformError: Equatable {
+extension DataTaskClient.Error: Equatable {
     public static func ==(lhs: Self, rhs: Self) -> Bool {
         switch (lhs, rhs) {
         case (.httpStatus(let codeLeft, let dataLeft), .httpStatus(let codeRight, let dataRight)):

--- a/Sources/Wire/Public/DataTaskClient/DataTaskClient+Error.swift
+++ b/Sources/Wire/Public/DataTaskClient/DataTaskClient+Error.swift
@@ -22,9 +22,10 @@ extension DataTaskClient {
             case .notHttpResponse(let response):
                 return "Not HTTP: \(response)."
             case .httpStatus(let code, let data):
+                let content = data.unboxed().utf8String(or: "* Content Not UTF-8 *")
                 return """
                 HTTP response status code: \(code), with data:
-                \(data.mapNil(as: Data()).utf8String(or: "* Content Not UTF-8 *"))
+                \(content)
                 """
             case .noData:
                 return "Server did not provide data."

--- a/Sources/Wire/Public/DataTaskClient/DataTaskClient.swift
+++ b/Sources/Wire/Public/DataTaskClient/DataTaskClient.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public final class DataTaskClient {
 
-    public typealias Completion<T> = (Result<T, WireBaseError>) -> Void
+    public typealias Completion<T> = (Result<T, WireError>) -> Void
 
     public static let shared: DataTaskClient = DataTaskClient(session: .shared)
 
@@ -62,29 +62,29 @@ public final class DataTaskClient {
         }
     }
 
-    func mappingTaskResponse(data: Data?, response: URLResponse?, error: Error?) -> Result<Data, WireBaseError> {
+    func mappingTaskResponse(data: Data?, response: URLResponse?, error: Swift.Error?) -> Result<Data, WireError> {
         if let error = error {
-            return .failure(WireBaseError.dataTaskPerformer(.sessionError(error)))
+            return .failure(.dataTaskClient(.sessionError(error)))
         }
         guard let response = response else {
-            return .failure(WireBaseError.dataTaskPerformer(.noResponse))
+            return .failure(.dataTaskClient(.noResponse))
         }
         guard let httpResponse = response as? HTTPURLResponse else {
-            return .failure(WireBaseError.dataTaskPerformer(.notHttpResponse(response: response)))
+            return .failure(.dataTaskClient(.notHttpResponse(response: response)))
         }
         guard httpResponse.statusCode == 200 else {
-            return .failure(WireBaseError.dataTaskPerformer(.httpStatus(code: httpResponse.statusCode, data: data)))
+            return .failure(.dataTaskClient(.httpStatus(code: httpResponse.statusCode, data: data)))
         }
         guard let data = data else {
-            return .failure(WireBaseError.dataTaskPerformer(.noData))
+            return .failure(.dataTaskClient(.noData))
         }
 
         return .success(data)
     }
 
-    func getResultOfResponseConversion<T: ResponseConvertible>(_ responseConverter: T, data: Data) -> Result<T.Output, WireBaseError> {
+    func getResultOfResponseConversion<T: ResponseConvertible>(_ responseConverter: T, data: Data) -> Result<T.Output, WireError> {
         return responseConverter.convert(data: data).mapError {
-            WireBaseError.responseConverter($0)
+            .responseConverter($0)
         }
     }
 

--- a/Sources/Wire/Public/Request.swift
+++ b/Sources/Wire/Public/Request.swift
@@ -68,14 +68,14 @@ public struct Request<Output> {
         let modifiers = dataModifiers.map {
             Modifier<Data>(closure: $0.modify)
         }
-        return iterateFailableModifiers(initial: data, modifiers)
+        return iterateFallibleModifiers(initial: data, modifiers)
     }
 
     private struct Modifier<T> {
         let closure: (T) -> Result<T, Error>
     }
 
-    private func iterateFailableModifiers<T>(initial: T, _ modifiers: [Modifier<T>]) -> Result<T, Error> {
+    private func iterateFallibleModifiers<T>(initial: T, _ modifiers: [Modifier<T>]) -> Result<T, Error> {
         var buffer = initial
         for modifier in modifiers {
             switch modifier.closure(buffer) {
@@ -93,7 +93,7 @@ extension Request: RequestBuildable {
             Modifier<URLRequest>(closure: $0.modify)
         }
         return builder.buildRequest().flatMap { request in
-            iterateFailableModifiers(initial: request, requestModifiers)
+            iterateFallibleModifiers(initial: request, requestModifiers)
         }
     }
 }
@@ -107,14 +107,14 @@ extension Request: ResponseConvertible {
 extension Request {
     public func retrieveData(
         using client: DataTaskClient = .shared,
-        completion: @escaping (Result<Data, WireBaseError>) -> Void
+        completion: @escaping (Result<Data, WireError>) -> Void
     ) {
         client.retrieveObject(with: self, responseConverter: dataModificationConverter, completion: completion)
     }
 
     public func retrieveObject(
         using client: DataTaskClient = .shared,
-        completion: @escaping (Result<Output, WireBaseError>) -> Void
+        completion: @escaping (Result<Output, WireError>) -> Void
     ) {
         client.retrieveObject(with: self, responseConverter: self, completion: completion)
     }
@@ -122,11 +122,11 @@ extension Request {
 
 @available(iOS 13.0, tvOS 13.0, watchOS 6.0, OSX 10.15, *)
 extension Request {
-    public func dataPublisher(using client: DataTaskClient = .shared) -> AnyPublisher<Data, WireBaseError> {
+    public func dataPublisher(using client: DataTaskClient = .shared) -> AnyPublisher<Data, WireError> {
         return client.objectPublisher(with: self, responseConverter: dataModificationConverter)
     }
 
-    public func objectPublisher(using client: DataTaskClient = .shared) -> AnyPublisher<Output, WireBaseError> {
+    public func objectPublisher(using client: DataTaskClient = .shared) -> AnyPublisher<Output, WireError> {
         return client.objectPublisher(with: self, responseConverter: self)
     }
 }

--- a/Sources/Wire/Types/ContentType.swift
+++ b/Sources/Wire/Types/ContentType.swift
@@ -8,10 +8,6 @@ public enum ContentType: RequestHeader {
     case plainText
     case customized(String)
 
-    public var mergesField: Bool {
-        return false
-    }
-
     public var key: String {
         return "Content-Type"
     }
@@ -30,5 +26,9 @@ public enum ContentType: RequestHeader {
         case .customized(let value):
             return value
         }
+    }
+
+    public var mergesField: Bool {
+        return false
     }
 }

--- a/Sources/Wire/Types/HTTPHeader.swift
+++ b/Sources/Wire/Types/HTTPHeader.swift
@@ -6,87 +6,87 @@ public struct HTTPHeader: RequestHeader {
     public let value: String
     public let mergesField: Bool
 
-    public init(key: String, value: String, mergesField: Bool = true) {
+    public init(key: String, value: String, mergesField: Bool = false) {
         self.key = key
         self.value = value
         self.mergesField = mergesField
     }
 
-    public static func accept(_ contentType: ContentType) -> HTTPHeader {
-        HTTPHeader(key: "Accept", value: contentType.value)
+    public static func accept(_ contentType: ContentType, mergesField: Bool = false) -> HTTPHeader {
+        HTTPHeader(key: "Accept", value: contentType.value, mergesField: mergesField)
     }
 
-    public static func acceptCharset(_ value: String) -> HTTPHeader {
-        HTTPHeader(key: "Accept-Charset", value: value)
+    public static func acceptCharset(_ value: String, mergesField: Bool = false) -> HTTPHeader {
+        HTTPHeader(key: "Accept-Charset", value: value, mergesField: mergesField)
     }
 
-    public static func acceptEncoding(_ value: String) -> HTTPHeader {
-        HTTPHeader(key: "Accept-Encoding", value: value)
+    public static func acceptEncoding(_ value: String, mergesField: Bool = false) -> HTTPHeader {
+        HTTPHeader(key: "Accept-Encoding", value: value, mergesField: mergesField)
     }
 
-    public static func acceptLanguage(_ value: String) -> HTTPHeader {
-        HTTPHeader(key: "Accept-Language", value: value)
+    public static func acceptLanguage(_ value: String, mergesField: Bool = false) -> HTTPHeader {
+        HTTPHeader(key: "Accept-Language", value: value, mergesField: mergesField)
     }
 
-    public static func acceptDateTime(_ value: String) -> HTTPHeader {
-        HTTPHeader(key: "Accept-Datetime", value: value)
+    public static func acceptDateTime(_ value: String, mergesField: Bool = false) -> HTTPHeader {
+        HTTPHeader(key: "Accept-Datetime", value: value, mergesField: mergesField)
     }
 
     public static func authorization(_ authorization: Authorization) -> HTTPHeader {
         authorization.asHTTPHeader
     }
 
-    public static func cacheControl(_ value: String) -> HTTPHeader {
-        HTTPHeader(key: "Cache-Control", value: value)
+    public static func cacheControl(_ value: String, mergesField: Bool = false) -> HTTPHeader {
+        HTTPHeader(key: "Cache-Control", value: value, mergesField: mergesField)
     }
 
-    public static func connection(_ value: String) -> HTTPHeader {
-        HTTPHeader(key: "Connection", value: value)
+    public static func connection(_ value: String, mergesField: Bool = false) -> HTTPHeader {
+        HTTPHeader(key: "Connection", value: value, mergesField: mergesField)
     }
 
-    public static func cookie(_ value: String) -> HTTPHeader {
-        HTTPHeader(key: "Cookie", value: value)
+    public static func cookie(_ value: String, mergesField: Bool = false) -> HTTPHeader {
+        HTTPHeader(key: "Cookie", value: value, mergesField: mergesField)
     }
 
     public static func contentType(_ contentType: ContentType) -> HTTPHeader {
         contentType.asHTTPHeader
     }
 
-    public static func contentMD5(_ value: String) -> HTTPHeader {
-        HTTPHeader(key: "Content-MD5", value: value)
+    public static func contentMD5(_ value: String, mergesField: Bool = false) -> HTTPHeader {
+        HTTPHeader(key: "Content-MD5", value: value, mergesField: mergesField)
     }
 
-    public static func date(_ value: String) -> HTTPHeader {
-        HTTPHeader(key: "Date", value: value)
+    public static func date(_ value: String, mergesField: Bool = false) -> HTTPHeader {
+        HTTPHeader(key: "Date", value: value, mergesField: mergesField)
     }
 
-    public static func expect(_ value: String) -> HTTPHeader {
-        HTTPHeader(key: "Expect", value: value)
+    public static func expect(_ value: String, mergesField: Bool = false) -> HTTPHeader {
+        HTTPHeader(key: "Expect", value: value, mergesField: mergesField)
     }
 
-    public static func from(_ value: String) -> HTTPHeader {
-        HTTPHeader(key: "From", value: value)
+    public static func from(_ value: String, mergesField: Bool = false) -> HTTPHeader {
+        HTTPHeader(key: "From", value: value, mergesField: mergesField)
     }
 
-    public static func ifMatch(_ value: String) -> HTTPHeader {
-        HTTPHeader(key: "If-Match", value: value)
+    public static func ifMatch(_ value: String, mergesField: Bool = false) -> HTTPHeader {
+        HTTPHeader(key: "If-Match", value: value, mergesField: mergesField)
     }
 
-    public static func keepAlive(_ value: String) -> HTTPHeader {
-        HTTPHeader(key: "Keep-Alive", value: value)
+    public static func keepAlive(_ value: String, mergesField: Bool = false) -> HTTPHeader {
+        HTTPHeader(key: "Keep-Alive", value: value, mergesField: mergesField)
     }
 
-    public static func referer(_ value: String) -> HTTPHeader {
-        HTTPHeader(key: "Referer", value: value)
+    public static func referer(_ value: String, mergesField: Bool = false) -> HTTPHeader {
+        HTTPHeader(key: "Referer", value: value, mergesField: mergesField)
     }
 
-    public static func userAgent(_ value: String) -> HTTPHeader {
-        HTTPHeader(key: "User-Agent", value: value)
+    public static func userAgent(_ value: String, mergesField: Bool = false) -> HTTPHeader {
+        HTTPHeader(key: "User-Agent", value: value, mergesField: mergesField)
     }
 }
 
-private extension RequestHeader {
-    var asHTTPHeader: HTTPHeader {
+extension RequestHeader {
+    fileprivate var asHTTPHeader: HTTPHeader {
         HTTPHeader(key: key, value: value, mergesField: mergesField)
     }
 }

--- a/Tests/WireTests/DataTaskClientTests.swift
+++ b/Tests/WireTests/DataTaskClientTests.swift
@@ -29,7 +29,7 @@ final class DataTaskClientTests: XCTestCase {
 
         let req = Request<Data>(builder: URL.noResponse, requestModifiers: [HTTPMethod.get])
         client.retrieveData(with: req) { result in
-            XCTAssertEqual(result.error as? WireBaseError, .dataTaskPerformer(.noResponse))
+            XCTAssertEqual(result.error as? WireError, .dataTaskClient(.noResponse))
             promise.fulfill()
         }
 
@@ -46,7 +46,7 @@ final class DataTaskClientTests: XCTestCase {
 
         let req = Request<Data>(builder: URL.notHTTP, requestModifiers: [HTTPMethod.get])
         client.retrieveData(with: req) { result in
-            XCTAssertEqual(result.error as? WireBaseError, .dataTaskPerformer(.notHttpResponse(response: urlResponse)))
+            XCTAssertEqual(result.error as? WireError, .dataTaskClient(.notHttpResponse(response: urlResponse)))
             promise.fulfill()
         }
 
@@ -62,7 +62,7 @@ final class DataTaskClientTests: XCTestCase {
 
         let req = Request<Data>(builder: URL.statusCode(401))
         client.retrieveData(with: req) { result in
-            XCTAssertEqual(result.error as? WireBaseError, .dataTaskPerformer(.httpStatus(code: 401, data: Data())))
+            XCTAssertEqual(result.error as? WireError, .dataTaskClient(.httpStatus(code: 401, data: Data())))
             promise.fulfill()
         }
 

--- a/Tests/WireTests/PlainTextBodyModifierTests.swift
+++ b/Tests/WireTests/PlainTextBodyModifierTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+@testable import Wire
+
+final class PlainTextBodyModifierTests: XCTestCase {
+    func testModify() throws {
+        let plainText = "name=Wire"
+        let request = Request<Data>(
+            builder: URL.demo,
+            requestModifiers: [
+                PlainTextBodyModifier(text: plainText, encoding: .utf8)
+            ])
+
+        let urlRequest = try request.buildRequest().get()
+
+        XCTAssertEqual(urlRequest.allHTTPHeaderFields?[ContentType.plainText.key], ContentType.plainText.value)
+        XCTAssertEqual(urlRequest.httpBody?.utf8String(), plainText)
+    }
+
+    func testEncodingFailure() throws {
+        let plainText = "name=Wire"
+        let request = Request<Data>(
+            builder: URL.demo,
+            requestModifiers: [
+                PlainTextBodyModifier(text: plainText, encoding: .symbol)
+            ])
+
+        XCTAssertThrowsError(try request.buildRequest().get(), "Request builder error") { error in
+            guard let err = error as? PlainTextBodyModifier.Error,
+                  case .encodingFailure = err
+            else {
+                return XCTFail("Unexpected error")
+            }
+        }
+    }
+}

--- a/Tests/WireTests/RequestBuildableTests.swift
+++ b/Tests/WireTests/RequestBuildableTests.swift
@@ -26,7 +26,7 @@ final class RequestBuildableTests: XCTestCase {
             let req = urlString.buildRequest()
 
             XCTAssertThrowsError(try req.get(), "") { error in
-                XCTAssertTrue(error as? WireBaseError == .invalidURLString(urlString))
+                XCTAssertTrue(error as? WireError == .invalidURLString(urlString))
             }
         }
     }

--- a/Tests/WireTests/RequestModifiableTests.swift
+++ b/Tests/WireTests/RequestModifiableTests.swift
@@ -8,12 +8,12 @@ final class RequestModifiableTests: XCTestCase {
             req.httpMethod = HTTPMethod.post.method
             return .success(req)
         }
-        let origReq = URLRequest(url: .demo)
-        let newReq = try requestModifier.modify(origReq).get()
+        let request = URLRequest(url: .demo)
+        let modifiedRequest = try requestModifier.modify(request).get()
 
-        XCTAssertEqual(origReq.url, newReq.url)
-        XCTAssertEqual(origReq.httpMethod, "GET")
-        XCTAssertEqual(newReq.httpMethod, "POST")
+        XCTAssertEqual(request.url, modifiedRequest.url)
+        XCTAssertEqual(request.httpMethod, "GET")
+        XCTAssertEqual(modifiedRequest.httpMethod, "POST")
     }
 
     func testFailure() {

--- a/Tests/WireTests/RequestTests.swift
+++ b/Tests/WireTests/RequestTests.swift
@@ -19,11 +19,7 @@ final class RequestTests: XCTestCase {
         let request = Request<Data>(
             builder: URLRequest(url: .demo),
             requestModifiers: [
-                AnyRequestModifier { req in
-                    var req = req
-                    req.httpMethod = "PUT"
-                    return .success(req)
-                },
+                HTTPMethod.put,
                 ContentType.plainText,
                 AnyRequestModifier { req in
                     var req = req


### PR DESCRIPTION
### Work been done
- Modify HTTPHeader static functions' interface
- Correct spelling
- Rename `WireBaseError` to WireError
- More test cases